### PR TITLE
Fix lost header

### DIFF
--- a/src/image/png_wrapper.cpp
+++ b/src/image/png_wrapper.cpp
@@ -6,6 +6,7 @@
 
 #include "saiga/image/png_wrapper.h"
 #include "saiga/util/assert.h"
+#include <cstring> // for memcpy
 #ifdef SAIGA_USE_PNG
 namespace Saiga {
 namespace PNG{


### PR DESCRIPTION
It didn't want to build with my GCC 7.1.1 on Linux without this header, so I guess it should be added.