### PR TITLE
Changes for OpenAL version 1.19+

### DIFF
--- a/src/saiga/core/sound/SoundManager.h
+++ b/src/saiga/core/sound/SoundManager.h
@@ -19,7 +19,7 @@
 #include <thread>
 #include <vector>
 
-typedef struct ALCdevice_struct ALCdevice;
+struct ALCdevice;
 
 namespace Saiga
 {

--- a/src/saiga/core/sound/SoundManager.h
+++ b/src/saiga/core/sound/SoundManager.h
@@ -19,7 +19,8 @@
 #include <thread>
 #include <vector>
 
-struct ALCdevice;
+#include <alc.h>
+
 
 namespace Saiga
 {


### PR DESCRIPTION
OpenAL 1.19 renamed ALCdevice_struct to ALCdevice, creating name clashes.
This change is not backward compatible, however, the versioning of the library did not change.
Therefore, we cannot check which one to use.